### PR TITLE
GpxChartingModule: show 2 decimal places for x val on split label

### DIFF
--- a/src/components/GpxChartingModule.tsx
+++ b/src/components/GpxChartingModule.tsx
@@ -246,7 +246,7 @@ export function GpxChartingModule(props: Props) {
   const splitLabel =
     splitData != null
       ? `${yValues[splitData.index].toFixed(1)} ${yUnits}
-${xValues[splitData.index].toFixed(1)} ${xUnits}`
+${xValues[splitData.index].toFixed(2)} ${xUnits}`
       : null;
 
   const aggregateForInterval = (start: number, end: number) => {


### PR DESCRIPTION
I didn't actually test this, had some issues with npx/eas/expo/etc when trying to run locally 😅